### PR TITLE
Fix handling for full URLs

### DIFF
--- a/pages/[hash]/index.js
+++ b/pages/[hash]/index.js
@@ -15,11 +15,16 @@ const RetrieveShortLink = () => {
   const getLink = async () => {
     try {
       const resp = await axiosShortLink(hash)
-      const link = resp.link.original_url
+      let link = resp.link.original_url
       toast.success(`${resp.link.original_url} found. Redirecting...`)
-      window.location.replace(`//${link}`)
-      // replace needs // in front to redirect correctly
-      // more details: https://stackoverflow.com/a/40368867/9163110
+
+      // If the URL has no scheme prefix (e.g., http:// or https://), assume
+      // that it's a plaintext http URL.
+      if (!/^[a-z0-9]+:\/\//.test(link)) {
+        link = "http://" + link
+      }
+
+      window.location.replace(link)
     } catch (error) {
       toast.error('domain does not exist. Redirecting...')
       await Router.push("/404")


### PR DESCRIPTION
This fixes a bug where if the user passed a full URL, including the https:// prefix, Shorty Links would inject an extraneous https// into the link. For example:

https://whatgotdone.com/dansult/2021-10-22 -> https://https//whatgotdone.com/dansult/2021-10-22

The root cause was a brittle workaround for location.replace where it prefixed the target link with // but that only works for URLs without schemes (e.g., google.com).

The // workaround also breaks for HTTP-only sites. For example, redirecting to neverssl.com breaks because it becomes //neverssl.com, and because Shorty Links is being served over SSL, //neverssl.com becomes https://neverssl.com. But really it's irrelevant whether Shorty Links is being served over SSL. If we don't know the scheme of the target, we have to guess either HTTP or HTTPS, so this implementation guesses that it's HTTP, though we could easily change the assumption to HTTPS.