### PR TITLE
Remove redirects from the front end with server-side redirection

### DIFF
--- a/components/ShortenLinkTableLocalStorage.jsx
+++ b/components/ShortenLinkTableLocalStorage.jsx
@@ -17,7 +17,7 @@ export default function ShortenLinkTableLocalStorage({links}) {
                   <tr>
                     <th
                       scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
                       Original URL
                     </th>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next-sitemap": "^1.6.173",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.17.5",
     "react-spinners": "^0.11.0",
     "react-table": "^7.7.0",
     "react-toastify": "^8.0.3",

--- a/pages/[hash]/index.js
+++ b/pages/[hash]/index.js
@@ -1,7 +1,7 @@
-import {axiosShortLink} from "../../lib/axiosHandler";
 import {useRouter} from "next/router";
 import {useEffect} from "react";
 import {toast} from "react-toastify";
+import {config} from "../../config";
 
 const RetrieveShortLink = () => {
   const Router = useRouter()
@@ -14,15 +14,7 @@ const RetrieveShortLink = () => {
   }, [Router.isReady, Router.query])
   const getLink = async () => {
     try {
-      const resp = await axiosShortLink(hash)
-      let link = resp.link.original_url
-      toast.success(`${resp.link.original_url} found. Redirecting...`)
-
-      // If the URL has no scheme prefix (e.g., http:// or https://), assume
-      // that it's a plaintext http URL.
-      if (!/^[a-z0-9]+:\/\//.test(link)) {
-        link = "http://" + link
-      }
+      let link = `${config.url.API_URL}/links/${hash}`
 
       window.location.replace(link)
     } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,6 +3328,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-hook-form@^7.17.5:
+  version "7.17.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.17.5.tgz#3852f294159378d0b5893c9fcc89e313937c6f89"
+  integrity sha512-4bPtPGkpVhZlgtTbtMGi0RFphKHgxCj5u3AsGz3SBdleELlG1pDf9zRQOtfGlOGkZlc7u78RzD0xu9kOw7PYdQ==
+
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
This PR removes redirection handling via the front end, pushing it off to the server. 

Also includes:

- Add error messages to the form handler
- Add `react-hook-form`